### PR TITLE
Compatibility with PHP 7 and Symfony 3 / Allow norkunas/onesignal-php-api fixs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "symfony/framework-bundle": "~2.3",
-    "norkunas/onesignal-php-api": "v0.1.0"
+    "php": ">=5.4.0 || ^7.0",
+    "symfony/framework-bundle": "~2.3 || ^3.0",
+    "norkunas/onesignal-php-api": "^0.1"
   },
   "require-dev": {
   },


### PR DESCRIPTION
Just update `composer.json` to:

- Make it compatible with PHP 7 and Symfony 3.
- Allow norkunas/onesignal-php-api fixs